### PR TITLE
Fixed broken link

### DIFF
--- a/coursework/lessons/slides/ruby-laptop-setup.md
+++ b/coursework/lessons/slides/ruby-laptop-setup.md
@@ -19,4 +19,4 @@ __We will not require you to host more than 5 apps, so giving your credit card i
 Once you've signed up for Heroku, it'll [give you instructions](https://devcenter.heroku.com/articles/getting-started-with-ruby#introduction) on how to set up your computer with Ruby. __Two important notes:__
 
 - __You only have to follow the instructions up to and including _Set up_.__
-- __If you're running Windows, Heroku will suggest installing JRuby instead of regular Ruby. Please ignore that suggestion and follow [the normal instructions for Windows](http://guides.railsgirls.com/install/#setup-for-windows).__
+- __If you're running Windows, Heroku will suggest installing JRuby instead of regular Ruby. Please ignore that suggestion and follow [the normal instructions for Windows](http://guides.railsgirls.com/install#setup-for-windows).__


### PR DESCRIPTION
Shay noticed that the link to instructions for installing Ruby on Rails on Windows was broken. As it turns out, the site just doesn't like that trailing slash in the URL anymore.
